### PR TITLE
Stop loss order added

### DIFF
--- a/lib/exchange.ex
+++ b/lib/exchange.ex
@@ -13,36 +13,12 @@ defmodule Exchange do
 
   """
   @spec place_order(order_params :: map(), ticker :: atom()) :: atom() | {atom(), String.t()}
-  def place_order(%{type: :limit} = order_params, ticker) do
+  def place_order(order_params, ticker) do
     order_params = Map.put(order_params, :ticker, ticker)
 
     case Exchange.Validations.cast_order(order_params) do
       {:ok, limit_order} ->
-        Exchange.MatchingEngine.place_limit_order(ticker, limit_order)
-
-      {:error, errors} ->
-        {:error, errors}
-    end
-  end
-
-  def place_order(%{type: :market} = order_params, ticker) do
-    order_params = Map.put(order_params, :ticker, ticker)
-
-    case Exchange.Validations.cast_order(order_params) do
-      {:ok, market_order} ->
-        Exchange.MatchingEngine.place_market_order(ticker, market_order)
-
-      {:error, errors} ->
-        {:error, errors}
-    end
-  end
-
-  def place_order(%{type: :marketable_limit} = order_params, ticker) do
-    order_params = Map.put(order_params, :ticker, ticker)
-
-    case Exchange.Validations.cast_order(order_params) do
-      {:ok, marketable_limit_order} ->
-        Exchange.MatchingEngine.place_marketable_limit_order(ticker, marketable_limit_order)
+        Exchange.MatchingEngine.place_order(ticker, limit_order)
 
       {:error, errors} ->
         {:error, errors}

--- a/lib/exchange/matching_engine.ex
+++ b/lib/exchange/matching_engine.ex
@@ -287,7 +287,7 @@ defmodule Exchange.MatchingEngine do
       {:reply, :error, order_book}
     else
       order = Order.assign_prices(order, order_book)
-      validity = Order.validy_price(order, order_book)
+      validity = Order.validate_price(order, order_book)
 
       case validity do
         :ok ->
@@ -302,8 +302,8 @@ defmodule Exchange.MatchingEngine do
 
           {:reply, :ok, order_book}
 
-        {:error, _cause} ->
-          {:reply, validity, order_book}
+        {:error, cause} ->
+          {:reply, {:error, cause}, order_book}
       end
     end
   end

--- a/lib/exchange/order.ex
+++ b/lib/exchange/order.ex
@@ -92,7 +92,8 @@ defmodule Exchange.Order do
     if side == :buy do
       case order_book.ask_min >= price * (1 + stop / 100) do
         true ->
-          order |> Map.put(:price, order_book.max_price - 1)
+          order
+          |> Map.put(:price, order_book.max_price - 1)
 
         _ ->
           order
@@ -100,7 +101,8 @@ defmodule Exchange.Order do
     else
       case order_book.bid_max <= price * (1 - stop / 100) do
         true ->
-          order |> Map.put(:price, order_book.min_price + 1)
+          order
+          |> Map.put(:price, order_book.min_price + 1)
 
         _ ->
           order

--- a/lib/exchange/order.ex
+++ b/lib/exchange/order.ex
@@ -98,7 +98,7 @@ defmodule Exchange.Order do
           order
       end
     else
-      case order_book.bid_max <= price * 1 - stop / 100 do
+      case order_book.bid_max <= price * (1 - stop / 100) do
         true ->
           order |> Map.put(:price, order_book.min_price + 1)
 

--- a/lib/exchange/order_book.ex
+++ b/lib/exchange/order_book.ex
@@ -805,7 +805,13 @@ defmodule Exchange.OrderBook do
     order.price
   end
 
-  @spec stop_loss_activation(atom | %{buy: map, sell: map}) :: atom | %{buy: map, sell: map}
+  @doc """
+    This function checks if there are any stop loss orders to activate. If yes then they are converted in market orders, removed and placed on the exchange.
+    ## Parameters
+    - order_book: OrderBook to update
+  """
+  @spec stop_loss_activation(order_book :: Exchange.OrderBook.order_book()) ::
+          Exchange.OrderBook.order_book()
   def stop_loss_activation(order_book) do
     activated_stop_loss_orders =
       (Map.to_list(order_book.buy) ++ Map.to_list(order_book.sell))

--- a/lib/exchange/order_book.ex
+++ b/lib/exchange/order_book.ex
@@ -825,7 +825,7 @@ defmodule Exchange.OrderBook do
     if activated_stop_loss_orders != [] do
       order_book =
         activated_stop_loss_orders
-        |> Enum.map(&(Order.assign_prices(&1, order_book) |> Map.put(:type, :market)))
+        |> Enum.map(&Order.assign_prices(&1, order_book))
         |> Enum.sort(fn a, b -> a.acknowledge_at < b.acknowledge_at end)
         |> Enum.reduce(order_book, fn order, acc ->
           acc

--- a/lib/exchange/order_book.ex
+++ b/lib/exchange/order_book.ex
@@ -802,10 +802,34 @@ defmodule Exchange.OrderBook do
         ) :: number
   def last_price(order_book, side) do
     order = get_latest_order(order_book, side)
+    order.price
+  end
 
-    case order do
-      nil -> 0
-      _ -> order.price
+  @spec stop_loss_activation(atom | %{buy: map, sell: map}) :: atom | %{buy: map, sell: map}
+  def stop_loss_activation(order_book) do
+    activated_stop_loss_orders =
+      (Map.to_list(order_book.buy) ++ Map.to_list(order_book.sell))
+      |> Enum.flat_map(fn {_pp, queue} -> queue end)
+      |> Enum.filter(fn order ->
+        order.type == :stop_loss and
+          ((order.price * (1 + order.stop / 100) < order_book.ask_min and order.side == :buy) or
+             (order.price * (1 - order.stop / 100) > order_book.bid_max and order.side == :sell))
+      end)
+
+    if activated_stop_loss_orders != [] do
+      order_book =
+        activated_stop_loss_orders
+        |> Enum.map(&(Order.assign_prices(&1, order_book) |> Map.put(:type, :market)))
+        |> Enum.sort(fn a, b -> a.acknowledge_at < b.acknowledge_at end)
+        |> Enum.reduce(order_book, fn order, acc ->
+          acc
+          |> OrderBook.dequeue_order(order)
+          |> OrderBook.price_time_match(order)
+        end)
+
+      stop_loss_activation(order_book)
+    else
+      order_book
     end
   end
 
@@ -815,6 +839,9 @@ defmodule Exchange.OrderBook do
       :sell -> order_book.sell
     end
     |> Enum.flat_map(fn {_k, v} -> v end)
-    |> Enum.max_by(fn order -> order.acknowledged_at end)
+    |> Enum.max_by(
+      fn order -> order.acknowledged_at end,
+      fn -> %Exchange.Order{} end
+    )
   end
 end

--- a/lib/exchange/order_book.ex
+++ b/lib/exchange/order_book.ex
@@ -826,7 +826,7 @@ defmodule Exchange.OrderBook do
       order_book =
         activated_stop_loss_orders
         |> Enum.map(&Order.assign_prices(&1, order_book))
-        |> Enum.sort(fn a, b -> a.acknowledge_at < b.acknowledge_at end)
+        |> Enum.sort(fn a, b -> a.acknowledged_at < b.acknowledged_at end)
         |> Enum.reduce(order_book, fn order, acc ->
           acc
           |> OrderBook.dequeue_order(order)

--- a/lib/exchange/utils.ex
+++ b/lib/exchange/utils.ex
@@ -121,7 +121,9 @@ defmodule Exchange.Utils do
       side: s,
       initial_size: z,
       size: z,
-      price: p
+      price: p,
+      acknowledged_at: DateTime.utc_now() |> DateTime.to_unix(:nanosecond),
+      modified_at: DateTime.utc_now() |> DateTime.to_unix(:nanosecond)
     }
   end
 

--- a/lib/exchange/utils.ex
+++ b/lib/exchange/utils.ex
@@ -196,7 +196,13 @@ defmodule Exchange.Utils do
           price: 3960
         }
       ]
-      |> Enum.map(&%{&1 | acknowledged_at: DateTime.utc_now() |> DateTime.to_unix(:nanosecond)})
+      |> Enum.map(
+        &%{
+          &1
+          | ticker: ticker,
+            acknowledged_at: DateTime.utc_now() |> DateTime.to_unix(:nanosecond)
+        }
+      )
 
     sell_book =
       [
@@ -237,11 +243,17 @@ defmodule Exchange.Utils do
           price: 4020
         }
       ]
-      |> Enum.map(&%{&1 | acknowledged_at: DateTime.utc_now() |> DateTime.to_unix(:nanosecond)})
+      |> Enum.map(
+        &%{
+          &1
+          | ticker: ticker,
+            acknowledged_at: DateTime.utc_now() |> DateTime.to_unix(:nanosecond)
+        }
+      )
 
     (buy_book ++ sell_book)
     |> Enum.each(fn order ->
-      Exchange.MatchingEngine.place_limit_order(ticker, order)
+      Exchange.MatchingEngine.place_order(ticker, order)
     end)
   end
 

--- a/lib/exchange/validations.ex
+++ b/lib/exchange/validations.ex
@@ -19,7 +19,7 @@ defmodule Exchange.Validations do
   """
   @spec cast_order(map) ::
           {:ok, Exchange.Order.order()} | {:error, String.t()}
-  def cast_order(%{type: :limit} = order_params) do
+  def cast_order(%{type: type} = order_params) when type == :limit or type == :stop_loss do
     validate(order_params)
   end
 

--- a/test/matching_engine_test.exs
+++ b/test/matching_engine_test.exs
@@ -35,7 +35,7 @@ defmodule MatchingEngineTest do
     end
 
     test "after one buy order" do
-      MatchingEngine.place_limit_order(
+      MatchingEngine.place_order(
         :AUXLND,
         Utils.sample_order(%{size: 1000, price: 4000, side: :buy})
       )
@@ -51,7 +51,7 @@ defmodule MatchingEngineTest do
     end
 
     test "spread after one sell order" do
-      MatchingEngine.place_limit_order(
+      MatchingEngine.place_order(
         :AUXLND,
         Utils.sample_order(%{size: 500, price: 3900, side: :sell})
       )
@@ -72,7 +72,7 @@ defmodule MatchingEngineTest do
       {:ok, ask_min_1} = MatchingEngine.ask_min(:AUXLND)
       {:ok, bid_max_1} = MatchingEngine.bid_max(:AUXLND)
 
-      MatchingEngine.place_limit_order(
+      MatchingEngine.place_order(
         :AUXLND,
         Utils.sample_order(%{size: 1000, price: 4000, side: :buy})
       )
@@ -84,7 +84,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 500, price: 3900, side: :sell})
       order = %{order | order_id: "10"}
 
-      MatchingEngine.place_limit_order(
+      MatchingEngine.place_order(
         :AUXLND,
         order
       )
@@ -96,7 +96,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 1000, price: 3900, side: :sell})
       order = %{order | order_id: "10"}
 
-      MatchingEngine.place_limit_order(
+      MatchingEngine.place_order(
         :AUXLND,
         order
       )
@@ -108,7 +108,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 250, price: 3800, side: :buy})
       order = %{order | order_id: "11"}
 
-      MatchingEngine.place_limit_order(
+      MatchingEngine.place_order(
         :AUXLND,
         order
       )
@@ -166,8 +166,8 @@ defmodule MatchingEngineTest do
           exp_time: t2
         })
 
-      MatchingEngine.place_limit_order(:AGZRC, buy_order)
-      MatchingEngine.place_limit_order(:AGZRC, sell_order)
+      MatchingEngine.place_order(:AGZRC, buy_order)
+      MatchingEngine.place_order(:AGZRC, sell_order)
       order_id_1 = buy_order.order_id
       order_id_2 = sell_order.order_id
       {:ok, ob} = MatchingEngine.order_book_entries(:AGZRC)
@@ -180,7 +180,7 @@ defmodule MatchingEngineTest do
       buy_order =
         Utils.sample_expiring_order(%{size: 750, price: 4010, side: :buy, id: "9", exp_time: t1})
 
-      MatchingEngine.place_limit_order(:AGZRC, buy_order)
+      MatchingEngine.place_order(:AGZRC, buy_order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AGZRC)
       assert ob.expiration_list == []
     end
@@ -191,7 +191,7 @@ defmodule MatchingEngineTest do
       order =
         Utils.sample_expiring_order(%{size: 1000, price: 3999, side: :buy, id: "9", exp_time: t})
 
-      MatchingEngine.place_limit_order(:AGZRC, order)
+      MatchingEngine.place_order(:AGZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AGZRC)
       assert [{t, order.order_id}] == ob.expiration_list
       assert [] == ob.expired_orders
@@ -215,7 +215,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 2000, price: 0, side: :buy})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
       {:ok, spread} = MatchingEngine.spread(:AUXZRC)
       {:ok, ask_min} = MatchingEngine.ask_min(:AUXZRC)
@@ -230,7 +230,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 750, price: 0, side: :sell})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
 
       {:ok, spread} = MatchingEngine.spread(:AUXZRC)
       {:ok, ask_min} = MatchingEngine.ask_min(:AUXZRC)
@@ -246,7 +246,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 100, price: 0, side: :buy})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order = ob.sell[4010] |> Enum.find(%Order{}, fn order -> order.order_id == "1" end)
@@ -257,7 +257,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 100, price: 0, side: :sell})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order = ob.buy[4000] |> Enum.find(%Order{}, fn order -> order.order_id == "4" end)
@@ -268,7 +268,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 10_000, price: 0, side: :buy})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order =
@@ -281,7 +281,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 10_000, price: 0, side: :sell})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order =
@@ -293,7 +293,7 @@ defmodule MatchingEngineTest do
     test "Place a limit buy order that consumes the top of the sell side" do
       order = Utils.sample_order(%{size: 2000, price: 4010, side: :buy})
 
-      MatchingEngine.place_limit_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
 
       {:ok, spread} = MatchingEngine.spread(:AUXZRC)
       {:ok, ask_min} = MatchingEngine.ask_min(:AUXZRC)
@@ -308,7 +308,7 @@ defmodule MatchingEngineTest do
     test "Place a limit sell order that consumes the top of the buy side" do
       order = Utils.sample_order(%{size: 750, price: 4000, side: :sell})
 
-      MatchingEngine.place_limit_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
 
       {:ok, spread} = MatchingEngine.spread(:AUXZRC)
       {:ok, ask_min} = MatchingEngine.ask_min(:AUXZRC)
@@ -322,7 +322,7 @@ defmodule MatchingEngineTest do
 
     test "Place a limit buy order that partially consumes the top order of the sell side" do
       order = Utils.sample_order(%{size: 100, price: 4010, side: :buy})
-      MatchingEngine.place_limit_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
       partial_order = ob.sell[4010] |> Enum.find(%Order{}, fn order -> order.order_id == "1" end)
       assert Map.get(partial_order, :size) == 650
@@ -331,7 +331,7 @@ defmodule MatchingEngineTest do
     test "Place a limit sell order that partially consumes the top order of the buy side" do
       order = Utils.sample_order(%{size: 100, price: 4000, side: :sell})
 
-      MatchingEngine.place_limit_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order = ob.buy[4000] |> Enum.find(%Order{}, fn order -> order.order_id == "4" end)
@@ -342,7 +342,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 10_000, price: 4010, side: :buy})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order =
@@ -357,7 +357,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 10_000, price: 4000, side: :sell})
       order = %Order{order | type: :market}
 
-      MatchingEngine.place_market_order(:AUXZRC, order)
+      MatchingEngine.place_order(:AUXZRC, order)
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       partial_order =
@@ -371,24 +371,24 @@ defmodule MatchingEngineTest do
     test "Place limit order with price higher than max_price" do
       order = Utils.sample_order(%{size: 100, price: 190_000, side: :sell})
 
-      code = MatchingEngine.place_limit_order(:AUXZRC, order)
+      code = MatchingEngine.place_order(:AUXZRC, order)
 
-      assert code == :error
+      assert code == {:error, :max_price_exceeded}
     end
 
     test "Place limit order with price lower than min_price" do
       order = Utils.sample_order(%{size: 100, price: 900, side: :sell})
 
-      code = MatchingEngine.place_limit_order(:AUXZRC, order)
+      code = MatchingEngine.place_order(:AUXZRC, order)
 
-      assert code == :error
+      assert code == {:error, :behind_min_price}
     end
 
     test "Place limit order with existing id" do
       order = Utils.sample_order(%{size: 100, price: 10_000, side: :sell})
       order = %Order{order | order_id: "4"}
 
-      code = MatchingEngine.place_limit_order(:AUXZRC, order)
+      code = MatchingEngine.place_order(:AUXZRC, order)
 
       assert code == :error
     end
@@ -397,7 +397,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 100, price: 10_000, side: :sell})
       order = %Order{order | type: :market, order_id: "4"}
 
-      code = MatchingEngine.place_market_order(:AUXZRC, order)
+      code = MatchingEngine.place_order(:AUXZRC, order)
 
       assert code == :error
     end
@@ -414,10 +414,10 @@ defmodule MatchingEngineTest do
       assert code == :error
     end
 
-    test "place marketable limit order(fullfilled)" do
+    test "Place marketable limit order(fullfilled)" do
       order = Utils.sample_order(%{size: 100, price: 0, side: :sell})
       order = %{order | type: :marketable_limit}
-      _code = MatchingEngine.place_marketable_limit_order(:AUXZRC, order)
+      _code = MatchingEngine.place_order(:AUXZRC, order)
 
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
       partial_order = OrderBook.fetch_order_by_id(ob, "4")
@@ -426,10 +426,10 @@ defmodule MatchingEngineTest do
       assert partial_order.side == :buy
     end
 
-    test "place marketable limit order(partial)" do
+    test "Place marketable limit order(partial)" do
       order = Utils.sample_order(%{size: 2100, price: 0, side: :buy})
       order = %{order | type: :marketable_limit, order_id: "120"}
-      _code = MatchingEngine.place_marketable_limit_order(:AUXZRC, order)
+      _code = MatchingEngine.place_order(:AUXZRC, order)
 
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
       partial_order = OrderBook.fetch_order_by_id(ob, "120")
@@ -438,19 +438,93 @@ defmodule MatchingEngineTest do
       assert partial_order.price == 4010
     end
 
-    test "place buy marketable limit order with empty sell" do
+    test "Place buy marketable limit order with empty sell" do
       order = Utils.sample_order(%{size: 2250, price: 4500, side: :buy})
       order = %{order | order_id: "100"}
-      _code = MatchingEngine.place_limit_order(:AUXZRC, order)
+      _code = MatchingEngine.place_order(:AUXZRC, order)
 
       order = Utils.sample_order(%{size: 1000, price: 0, side: :buy})
       order = %{order | type: :marketable_limit, order_id: "120"}
-      _code = MatchingEngine.place_marketable_limit_order(:AUXZRC, order)
+      _code = MatchingEngine.place_order(:AUXZRC, order)
 
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
       partial_order = OrderBook.fetch_order_by_id(ob, "120")
       assert partial_order.size == 1000
       assert partial_order.price == ob.max_price - 1
+    end
+
+    test "Place stop loss" do
+      order = Utils.sample_order(%{size: 2100, price: 4010, side: :buy})
+      order = %{order | order_id: "100", type: :stop_loss, stop: 20}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
+
+      partial_order = OrderBook.fetch_order_by_id(ob, "100")
+      assert partial_order.size == 100
+      assert partial_order.order_id == "100"
+    end
+
+    test "Place stop loss and trigger it to market" do
+      order = Utils.sample_order(%{size: 2100, price: 4010, side: :buy})
+      order = %{order | order_id: "100", type: :stop_loss, stop: 20}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+
+      order = Utils.sample_order(%{size: 1000, price: 4010, side: :buy})
+      order = %{order | order_id: "101", type: :market}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
+      partial_order = OrderBook.fetch_order_by_id(ob, "100")
+      assert partial_order.size == 100
+      assert partial_order.order_id == "100"
+      assert partial_order.price == ob.max_price - 1
+    end
+
+    test "Place stop loss order, trigger and complete it trade" do
+      order = Utils.sample_order(%{size: 1000, price: 4010, side: :sell})
+      order = %{order | order_id: "100", type: :stop_loss, stop: 20}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      order = Utils.sample_order(%{size: 1000, price: 3000, side: :buy})
+      order = %{order | order_id: "102", type: :limit}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      order = Utils.sample_order(%{size: 1650, price: 4010, side: :sell})
+      order = %{order | order_id: "101", type: :market}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
+      partial_order = OrderBook.fetch_order_by_id(ob, "100")
+      assert partial_order == nil
+    end
+
+    test "Place stop loss orders, trigger and complete both to trade" do
+      order = Utils.sample_order(%{size: 1000, price: 4008, side: :sell})
+      order = %{order | order_id: "100", type: :stop_loss, stop: 99}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+
+      order = Utils.sample_order(%{size: 1000, price: 3819, side: :buy})
+      order = %{order | order_id: "101", type: :stop_loss, stop: 5}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+
+      order = Utils.sample_order(%{size: 1500, price: 0, side: :sell})
+      order = %{order | order_id: "102", type: :market}
+
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
+
+      order_1 = OrderBook.fetch_order_by_id(ob, "100")
+      order_2 = OrderBook.fetch_order_by_id(ob, "101")
+      assert order_1 == nil
+      assert order_2 == nil
+    end
+
+    test "Place stop loss order with order already at the stop" do
+      order = Utils.sample_order(%{size: 1650, price: 5000, side: :sell})
+      order = %{order | order_id: "100", type: :stop_loss, stop: 99}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      order = Utils.sample_order(%{size: 2250, price: 3000, side: :buy})
+      order = %{order | order_id: "101", type: :stop_loss, stop: 1}
+      _code = MatchingEngine.place_order(:AUXZRC, order)
+      {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
+      assert ob.buy == %{}
+      assert ob.sell == %{}
     end
   end
 
@@ -477,7 +551,7 @@ defmodule MatchingEngineTest do
     test "Volumes after sell order that consumes the buy side" do
       order = Utils.sample_order(%{size: 1800, price: 1010, side: :sell})
 
-      MatchingEngine.place_limit_order(:AGLND, order)
+      MatchingEngine.place_order(:AGLND, order)
 
       {:ok, ask_volume} = MatchingEngine.ask_volume(:AGLND)
       {:ok, bid_volume} = MatchingEngine.bid_volume(:AGLND)
@@ -488,7 +562,7 @@ defmodule MatchingEngineTest do
     test "Volumes after sell order that partially consumes the buy side" do
       order = Utils.sample_order(%{size: 1500, price: 1010, side: :sell})
 
-      MatchingEngine.place_limit_order(:AGLND, order)
+      MatchingEngine.place_order(:AGLND, order)
 
       {:ok, ask_volume} = MatchingEngine.ask_volume(:AGLND)
       {:ok, bid_volume} = MatchingEngine.bid_volume(:AGLND)
@@ -499,7 +573,7 @@ defmodule MatchingEngineTest do
     test "Volumes after buy order that consumes the sell side" do
       order = Utils.sample_order(%{size: 2500, price: 4050, side: :buy})
 
-      MatchingEngine.place_limit_order(:AGLND, order)
+      MatchingEngine.place_order(:AGLND, order)
 
       {:ok, ask_volume} = MatchingEngine.ask_volume(:AGLND)
       {:ok, bid_volume} = MatchingEngine.bid_volume(:AGLND)
@@ -510,7 +584,7 @@ defmodule MatchingEngineTest do
     test "Volumes after buy order that partially consumes the sell side" do
       order = Utils.sample_order(%{size: 2000, price: 4050, side: :buy})
 
-      MatchingEngine.place_limit_order(:AGLND, order)
+      MatchingEngine.place_order(:AGLND, order)
 
       {:ok, ask_volume} = MatchingEngine.ask_volume(:AGLND)
       {:ok, bid_volume} = MatchingEngine.bid_volume(:AGLND)
@@ -535,7 +609,7 @@ defmodule MatchingEngineTest do
     test "After adding buy order that consumes 1 or more sell orders" do
       order = Utils.sample_order(%{size: 2000, price: 4010, side: :buy})
 
-      MatchingEngine.place_limit_order(:AUXUS, order)
+      MatchingEngine.place_order(:AUXUS, order)
       {:ok, total_bid_orders} = MatchingEngine.total_bid_orders(:AUXUS)
       {:ok, total_ask_orders} = MatchingEngine.total_ask_orders(:AUXUS)
       assert total_bid_orders == 4
@@ -545,7 +619,7 @@ defmodule MatchingEngineTest do
     test "After adding sell order that consumes 1 or more buy orders" do
       order = Utils.sample_order(%{size: 2000, price: 4000, side: :sell})
 
-      MatchingEngine.place_limit_order(:AUXUS, order)
+      MatchingEngine.place_order(:AUXUS, order)
       {:ok, total_bid_orders} = MatchingEngine.total_bid_orders(:AUXUS)
       {:ok, total_ask_orders} = MatchingEngine.total_ask_orders(:AUXUS)
       assert total_bid_orders == 2
@@ -555,7 +629,7 @@ defmodule MatchingEngineTest do
     test "After adding buy order" do
       order = Utils.sample_order(%{size: 2000, price: 3000, side: :buy})
 
-      MatchingEngine.place_limit_order(:AUXUS, order)
+      MatchingEngine.place_order(:AUXUS, order)
 
       {:ok, total_bid_orders} = MatchingEngine.total_bid_orders(:AUXUS)
 
@@ -568,7 +642,7 @@ defmodule MatchingEngineTest do
     test "After adding sell order" do
       order = Utils.sample_order(%{size: 1000, price: 5000, side: :sell})
 
-      MatchingEngine.place_limit_order(:AUXUS, order)
+      MatchingEngine.place_order(:AUXUS, order)
 
       {:ok, total_bid_orders} = MatchingEngine.total_bid_orders(:AUXUS)
 
@@ -630,7 +704,7 @@ defmodule MatchingEngineTest do
       order = Utils.sample_order(%{size: 2000, price: 4000, side: :sell})
       order = %Order{order | trader_id: "alchemist0"}
 
-      MatchingEngine.place_limit_order(:KAPPA, order)
+      MatchingEngine.place_order(:KAPPA, order)
 
       {:ok, orders} = MatchingEngine.open_orders_by_trader(:KAPPA, "alchemist0")
 
@@ -646,7 +720,7 @@ defmodule MatchingEngineTest do
       order_1 = Utils.sample_order(%{size: 2000, price: 3200, side: :buy})
       order_1 = %Order{order_1 | trader_id: "alchemist0", order_id: "100"}
 
-      MatchingEngine.place_limit_order(:KAPPA, order_1)
+      MatchingEngine.place_order(:KAPPA, order_1)
 
       {:ok, order} = MatchingEngine.open_order_by_id(:KAPPA, "100")
 
@@ -661,9 +735,9 @@ defmodule MatchingEngineTest do
       order_1 = %Order{order_1 | trader_id: "alchemist0", order_id: "100"}
       order_2 = %Order{order_2 | trader_id: "alchemist0"}
 
-      MatchingEngine.place_limit_order(:KAPPA, order_1)
+      MatchingEngine.place_order(:KAPPA, order_1)
 
-      MatchingEngine.place_limit_order(:KAPPA, order_2)
+      MatchingEngine.place_order(:KAPPA, order_2)
 
       {:ok, orders} = MatchingEngine.open_orders_by_trader(:KAPPA, "alchemist0")
 
@@ -707,8 +781,8 @@ defmodule MatchingEngineTest do
       order_1 = %Order{order_1 | trader_id: "alchemist0", order_id: "100"}
       order_2 = %Order{order_2 | trader_id: "alchemist9", order_id: "101"}
       ids = ~w(100 101)
-      MatchingEngine.place_limit_order(:BTCUS, order_1)
-      MatchingEngine.place_limit_order(:BTCUS, order_2)
+      MatchingEngine.place_order(:BTCUS, order_1)
+      MatchingEngine.place_order(:BTCUS, order_2)
 
       order_queued_ids =
         TestEventBus.value()
@@ -744,8 +818,8 @@ defmodule MatchingEngineTest do
       order_1 = %Order{order_1 | trader_id: "alchemist0", order_id: "100"}
       order_2 = %Order{order_2 | trader_id: "alchemist9"}
       ids = ~w(100 9)
-      MatchingEngine.place_limit_order(:BTCUS, order_1)
-      MatchingEngine.place_limit_order(:BTCUS, order_2)
+      MatchingEngine.place_order(:BTCUS, order_1)
+      MatchingEngine.place_order(:BTCUS, order_2)
       MatchingEngine.cancel_order(:BTCUS, "9")
       MatchingEngine.cancel_order(:BTCUS, "100")
 
@@ -778,7 +852,7 @@ defmodule MatchingEngineTest do
       t = (DateTime.utc_now() |> DateTime.to_unix(:millisecond)) - 2000
       order_1 = %Order{order_1 | trader_id: "alchemist0", order_id: "100", exp_time: t}
 
-      MatchingEngine.place_limit_order(:BTCUS, order_1)
+      MatchingEngine.place_order(:BTCUS, order_1)
       :timer.sleep(3000)
 
       expired_ids =
@@ -800,8 +874,8 @@ defmodule MatchingEngineTest do
       order_1 = %Order{order_1 | trader_id: "alchemist0", order_id: "100"}
       order_2 = %Order{order_2 | trader_id: "alchemist0"}
       ids = ~w(100 9)
-      MatchingEngine.place_limit_order(:BTCUS, order_1)
-      MatchingEngine.place_limit_order(:BTCUS, order_2)
+      MatchingEngine.place_order(:BTCUS, order_1)
+      MatchingEngine.place_order(:BTCUS, order_2)
 
       queue_ids =
         TestEventBus.value()

--- a/test/matching_engine_test.exs
+++ b/test/matching_engine_test.exs
@@ -496,7 +496,7 @@ defmodule MatchingEngineTest do
 
     test "Place stop loss orders, trigger and complete both to trade" do
       order = Utils.sample_order(%{size: 1000, price: 4008, side: :sell})
-      order = %{order | order_id: "100", type: :stop_loss, stop: 99}
+      order = %{order | order_id: "100", type: :stop_loss, stop: 1}
       _code = MatchingEngine.place_order(:AUXZRC, order)
 
       order = Utils.sample_order(%{size: 1000, price: 3819, side: :buy})
@@ -505,8 +505,8 @@ defmodule MatchingEngineTest do
 
       order = Utils.sample_order(%{size: 1500, price: 0, side: :sell})
       order = %{order | order_id: "102", type: :market}
-
       _code = MatchingEngine.place_order(:AUXZRC, order)
+
       {:ok, ob} = MatchingEngine.order_book_entries(:AUXZRC)
 
       order_1 = OrderBook.fetch_order_by_id(ob, "100")
@@ -517,7 +517,7 @@ defmodule MatchingEngineTest do
 
     test "Place stop loss order with order already at the stop" do
       order = Utils.sample_order(%{size: 1650, price: 5000, side: :sell})
-      order = %{order | order_id: "100", type: :stop_loss, stop: 99}
+      order = %{order | order_id: "100", type: :stop_loss, stop: 1}
       _code = MatchingEngine.place_order(:AUXZRC, order)
       order = Utils.sample_order(%{size: 2250, price: 3000, side: :buy})
       order = %{order | order_id: "101", type: :stop_loss, stop: 1}

--- a/test/matching_engine_test.exs
+++ b/test/matching_engine_test.exs
@@ -1066,10 +1066,11 @@ defmodule MatchingEngineTest do
         |> Enum.map(fn order ->
           order.order_id
         end)
+        |> Enum.sort()
 
       assert Enum.count(ts_ids) == 4
-      assert ts_ids == ids
-      assert ts_sizes == [1000, 1000, 0, 0]
+      assert ts_ids == Enum.sort(ids)
+      assert ts_sizes == [1000, 0, 1000, 0]
     end
 
     test "check if orders are cancelled" do
@@ -1121,10 +1122,11 @@ defmodule MatchingEngineTest do
         |> Enum.map(fn order ->
           order.order_id
         end)
+        |> Enum.sort()
 
       assert Enum.count(ts_ids) == 4
-      assert ts_ids == ids
-      assert ts_sizes == [1000, 1000, 0, 0]
+      assert ts_ids == Enum.sort(ids)
+      assert ts_sizes == [1000, 0, 1000, 0]
     end
 
     test "check if prices are broadcasted" do


### PR DESCRIPTION
Refactored calls to place orders in and exchange and matching engine.
Added an attribute to Exchange.Order, stop; it is expressed in percentage and it is used in stop_loss_activation/1 to decide if a stop_loss order should pass to a market order.